### PR TITLE
feat: enhance file type detection by using file extensions instead of mimetypes

### DIFF
--- a/apps/mobile/models/course.py
+++ b/apps/mobile/models/course.py
@@ -1,5 +1,3 @@
-import mimetypes
-
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
@@ -103,16 +101,41 @@ class CourseLessonResource(AbstractBaseModel):
 
     def get_file_type(self, file=None):
         if file:
-            mime_type = mimetypes.guess_type(file)[0]
-            if mime_type:
-                if mime_type.startswith("video"):
-                    return ResourceTypes.VIDEO
-                elif mime_type.startswith("audio"):
-                    return ResourceTypes.AUDIO
-                elif mime_type.startswith("application") or mime_type.startswith(
-                    "text"
-                ):
-                    return ResourceTypes.DOCUMENT
+            file_lower = file.lower()
+
+            video_extensions = (
+                ".mp4",
+                ".avi",
+                ".mov",
+                ".wmv",
+                ".flv",
+                ".mkv",
+                ".webm",
+                ".mpeg",
+                ".mpg",
+                ".3gp",
+            )
+            audio_extensions = (".mp3", ".wav", ".ogg", ".aac", ".flac", ".m4a", ".wma")
+            document_extensions = (
+                ".pdf",
+                ".doc",
+                ".docx",
+                ".txt",
+                ".rtf",
+                ".xls",
+                ".xlsx",
+                ".ppt",
+                ".pptx",
+                ".odt",
+            )
+
+            if file_lower.endswith(video_extensions):
+                return ResourceTypes.VIDEO
+            elif file_lower.endswith(audio_extensions):
+                return ResourceTypes.AUDIO
+            elif file_lower.endswith(document_extensions):
+                return ResourceTypes.DOCUMENT
+
         return ResourceTypes.DOCUMENT
 
     get_file_type.short_description = _("File Type")


### PR DESCRIPTION
This pull request includes changes to the `apps/mobile/models/course.py` file, focusing on improving the method for determining file types by replacing the use of the `mimetypes` library with file extension checks.

### Improvements to file type determination:

* Removed the import of the `mimetypes` library as it is no longer needed (`apps/mobile/models/course.py`).
* Modified the `get_file_type` method to use file extension checks instead of `mimetypes.guess_type`. This includes defining lists of common video, audio, and document file extensions and checking if the file ends with any of these extensions to determine its type (`apps/mobile/models/course.py`).… mimetypes