### PR TITLE
feat: extend JWT token lifetimes for improved user session management

### DIFF
--- a/core/config/jwt.py
+++ b/core/config/jwt.py
@@ -2,8 +2,8 @@ import os
 from datetime import timedelta
 
 SIMPLE_JWT = {
-    "ACCESS_TOKEN_LIFETIME": timedelta(days=1),
-    "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
+    "ACCESS_TOKEN_LIFETIME": timedelta(days=7),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=30),
     "ROTATE_REFRESH_TOKENS": False,
     "BLACKLIST_AFTER_ROTATION": False,
     "UPDATE_LAST_LOGIN": False,
@@ -25,8 +25,8 @@ SIMPLE_JWT = {
     "TOKEN_USER_CLASS": "rest_framework_simplejwt.models.TokenUser",
     "JTI_CLAIM": "jti",
     "SLIDING_TOKEN_REFRESH_EXP_CLAIM": "refresh_exp",
-    "SLIDING_TOKEN_LIFETIME": timedelta(days=1),
-    "SLIDING_TOKEN_REFRESH_LIFETIME": timedelta(days=7),
+    "SLIDING_TOKEN_LIFETIME": timedelta(days=7),
+    "SLIDING_TOKEN_REFRESH_LIFETIME": timedelta(days=30),
     "TOKEN_OBTAIN_SERIALIZER": "rest_framework_simplejwt.serializers.TokenObtainPairSerializer",
     "TOKEN_REFRESH_SERIALIZER": "rest_framework_simplejwt.serializers.TokenRefreshSerializer",
     "TOKEN_VERIFY_SERIALIZER": "rest_framework_simplejwt.serializers.TokenVerifySerializer",


### PR DESCRIPTION
This pull request includes changes to the JWT configuration to extend the token lifetimes.

Token lifetime changes in `core/config/jwt.py`:

* Increased `ACCESS_TOKEN_LIFETIME` from 1 day to 7 days.
* Increased `REFRESH_TOKEN_LIFETIME` from 7 days to 30 days.
* Increased `SLIDING_TOKEN_LIFETIME` from 1 day to 7 days.
* Increased `SLIDING_TOKEN_REFRESH_LIFETIME` from 7 days to 30 days.